### PR TITLE
Fix accidently hide of error output

### DIFF
--- a/bin/mono
+++ b/bin/mono
@@ -67,10 +67,10 @@ function runSingleCommand($directory, $command)
         chdir($directory);
 
         echo "Executing in $directory: " . $command . PHP_EOL;
-        exec($command, $output,$exitCode);
+        exec($command, $output, $exitCode);
 
         if ($exitCode !== 0) {
-            // echo implode(PHP_EOL, $output) . PHP_EOL;
+            echo implode(PHP_EOL, $output) . PHP_EOL;
 
             exit($exitCode);
         }


### PR DESCRIPTION
The error when a command return a none zero exit code was not outputted. Accidently the line was uncommented. With the following fix the errors are again correctly outputted:

Before:

<img width="842" alt="Bildschirmfoto 2023-10-28 um 14 16 42" src="https://github.com/alexander-schranz/mono/assets/1698337/c4fc937e-8618-4da7-97af-217f92134bc8">

After:

<img width="816" alt="Bildschirmfoto 2023-10-28 um 14 16 05" src="https://github.com/alexander-schranz/mono/assets/1698337/c83bf647-e1b3-440b-898a-5629e26919fc">

