### PR TITLE
Upgrade frankdejonge/use-subsplit-publish from 1.0.0-beta7 to 1.0.0

### DIFF
--- a/bin/mono
+++ b/bin/mono
@@ -166,27 +166,30 @@ jobs:
         runs-on: ubuntu-latest
         name: Publish package sub-splits
         steps:
-            -   uses: actions/checkout@v2
-                with:
-                    fetch-depth: '0'
-                    persist-credentials: 'false'
-            -   uses: frankdejonge/use-github-token@1.0.1
-                with:
-                    authentication: 'YOUR_USERNAME:${{ secrets.PERSONAL_ACCESS_TOKEN }}'
-                    user_name: 'YOUR NAME'
-                    user_email: 'YOUR@EMAIL'
-            -   name: Cache splitsh-lite
-                id: splitsh-cache
-                uses: actions/cache@v2
-                with:
-                    path: './.splitsh'
-                    key: '${{ runner.os }}-splitsh'
-            -   uses: frankdejonge/use-subsplit-publish@1.0.0-beta.7
-                with:
-                    source-branch: '${{ github.ref_name }}'
-                    config-path: './config.subsplit-publish.json'
-                    splitsh-path: './.splitsh/splitsh-lite'
-                    splitsh-version: 'v1.0.1'
+            - uses: actions/checkout@v2
+              with:
+                  fetch-depth: '0'
+                  persist-credentials: 'false'
+
+            - uses: frankdejonge/use-github-token@1.0.1
+              with:
+                  authentication: 'YOUR_USERNAME:${{ secrets.PERSONAL_ACCESS_TOKEN }}'
+                  user_name: 'YOUR NAME'
+                  user_email: 'YOUR@EMAIL'
+
+            - name: Cache splitsh-lite
+              id: splitsh-cache
+              uses: actions/cache@v3
+              with:
+                  path: './.splitsh'
+                  key: '${{ runner.os }}-splitsh'
+
+            - uses: frankdejonge/use-subsplit-publish@1.0.0
+              with:
+                  source-branch: '${{ github.ref_name }}'
+                  config-path: './config.subsplit-publish.json'
+                  splitsh-path: './.splitsh/splitsh-lite'
+                  splitsh-version: 'v1.0.1'
 
 EOT;
 


### PR DESCRIPTION
A stable version of `frankdejonge/use-subsplit-publish` was released which we can use now.