### PR TITLE
Add upgrade-dependency command for easier handle a dependency update over several packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,3 +52,13 @@ vendor/bin/mono run composer lint # runs in my case various linters (phpstan, ph
 ```
 
 Mono is used and was build for managing [schranz-search monorepository](https://github.com/schranz-search/schranz-search).
+
+## Upgrade dependency
+
+If you have one dependency used in multiple packages and want to upgrade it in all packages you can use:
+
+```bash
+vendor/bin/mono upgrade-dependency phpstan/phpstan
+```
+
+Mono search for all packages which has then `phpstan/phpstan` in it and update it to the latest stable version.

--- a/bin/mono
+++ b/bin/mono
@@ -66,7 +66,10 @@ function runSingleCommand($directory, $command)
     try {
         chdir($directory);
 
-        echo "Executing in $directory: " . $command . PHP_EOL;
+        echo PHP_EOL;
+        echo "Mono executes > $command" . PHP_EOL;
+        echo PHP_EOL;
+
         exec($command, $output, $exitCode);
 
         if ($exitCode !== 0) {
@@ -84,8 +87,10 @@ function runSingleCommand($directory, $command)
 function runCommand(array $packages, array $arguments) {
     // Output the result
     foreach ($packages as $package) {
-        $directory = str_replace(getcwd(), '.', $package['directory']);
-        echo "Composer.json found in directory: " . $directory . PHP_EOL;
+        $directory = \str_replace(getcwd(), '.', $package['directory']);
+        $title = "`composer.json` found in directory: `" . substr($directory, 2) . '`' . PHP_EOL;
+        echo $title;
+        echo \str_repeat('=', \strlen($title) - 1) . PHP_EOL;
 
         if (count($arguments)) {
             runSingleCommand($directory, implode(' ', $arguments));

--- a/bin/mono
+++ b/bin/mono
@@ -84,6 +84,46 @@ function runSingleCommand($directory, $command)
     }
 }
 
+function upgradeDependencies(array $packages, array $arguments) {
+    $newVersions = [];
+    foreach ($arguments as $argument) {
+        $data = \json_decode(\file_get_contents('https://repo.packagist.org/p2/' . $argument . '.json'), true, 512, \JSON_THROW_ON_ERROR);
+        $lastVersion = $data['packages'][$argument][0]['version_normalized'];
+        $newVersionParts = \explode('.', $lastVersion, 3);
+        $newVersion = $newVersionParts[0] . '.' . $newVersionParts[1];
+        $newVersions[$argument] = $newVersion;
+    }
+
+    // Output the result
+    foreach ($packages as $package) {
+        $directory = \str_replace(getcwd(), '.', $package['directory']);
+        $composerFilePath = $directory . '/composer.json';
+        if (!file_exists($composerFilePath)) {
+            continue;
+        }
+
+        $composer = \json_decode(\file_get_contents($composerFilePath), true, 512, \JSON_THROW_ON_ERROR);
+
+        $dependencies = [...($composer['require'] ?? []), ...($composer['require-dev'] ?? [])];
+
+        foreach ($dependencies as $name => $version) {
+            if (\in_array($name, ['php'], true) || \str_starts_with($name, 'ext-')) {
+                continue;
+            }
+
+            if (!\in_array($name, $arguments, true)) {
+                continue;
+            }
+
+            $isDev = isset($composer['require-dev'][$name]);
+
+            echo 'Upgrade "' . $name . '" from ' . $version . ' to "' . $newVersions[$name] . " in " . $directory . '"' . PHP_EOL;
+
+            runSingleCommand($directory, 'composer require ' . $name . ':^' . $newVersions[$name] . ' --with-all-dependencies' . ' ' . ($isDev ? '--dev' : ''));
+        }
+    }
+}
+
 function runCommand(array $packages, array $arguments) {
     // Output the result
     foreach ($packages as $package) {
@@ -235,6 +275,7 @@ $packages = findPackages(getcwd());
 
 $return = match ($command) {
     'init-split' => initSplit($packages, $arguments),
+    'upgrade-dependency' => upgradeDependencies($packages, $arguments),
     'run' => runCommand($packages, $arguments),
     default => exit(1),
 };


### PR DESCRIPTION

If you have one dependency used in multiple packages and want to upgrade it in all packages you can use:

```bash
vendor/bin/mono upgrade-dependency phpstan/phpstan
```

Mono search for all packages which has then `phpstan/phpstan` in it and update it to the latest stable version.