### PR TITLE
Fix exit without return int

### DIFF
--- a/bin/mono
+++ b/bin/mono
@@ -166,6 +166,7 @@ function renameBranch(array $packages, array $arguments) {
                 ++$exit;
 
                 echo 'Error in "' . $package['name'] . '":' . PHP_EOL . '    ' . $error['message'] . PHP_EOL;
+
                 continue;
             }
         }
@@ -374,4 +375,4 @@ $return = match ($command) {
     default => 1,
 };
 
-exit($return);
+exit($return ?? 0);


### PR DESCRIPTION
PHP Deprecated:  exit(): Passing null to parameter #1 ($status) of type string|int is deprecated in /Users/alexanderschranz/Documents/Projects/schranz-search/vendor/schranz/mono/bin/mono on line 382